### PR TITLE
* Bumped to version 0.3.1

### DIFF
--- a/includes/class-wp-job-board-api-manager-base.php
+++ b/includes/class-wp-job-board-api-manager-base.php
@@ -62,12 +62,15 @@ class WP_Job_Board_API_Manager_Base
             }
         }
 
+        // Increasing timeout to way more than 5 seconds because reasons.
+        $args['timeout'] = 120;
+
         $response = $func($endpoint_url, $args);
         $code     = wp_remote_retrieve_response_code($response);
         $message  = wp_remote_retrieve_response_message($response);
 
         if ($response instanceof WP_Error) {
-            $this->throw_error("Could not reach {$endpoint_url} - {$code} - {$message}");
+            $this->throw_error("Could not reach {$endpoint_url} - {$response->get_error_code()} - {$response->get_error_message()}");
         }
 
         $body    = wp_remote_retrieve_body($response);

--- a/wp-job-board.php
+++ b/wp-job-board.php
@@ -11,7 +11,7 @@
  * Plugin Name:       WP Job Board
  * Plugin URI:        https://little-fork.com/
  * Description:       Aggregates and displays job listings from your ATS on your WordPress website
- * Version:           0.3.0
+ * Version:           0.3.1
  * Requires at least: 6.0
  * Requires PHP:      8.2
  * Author:            Little Fork
@@ -27,7 +27,7 @@ if (!defined('WPINC')) {
 /**
  * Currently plugin version.
  */
-define('WP_JOB_BOARD_VERSION', '0.3.0');
+define('WP_JOB_BOARD_VERSION', '0.3.1');
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
* Extended timeout for wp_remote_{METHOD} call
* Improved messaging when a call fails to use actual error codes and messaging